### PR TITLE
Creating a balanced Catalyst reaction

### DIFF
--- a/src/TestPackage.jl
+++ b/src/TestPackage.jl
@@ -2,6 +2,8 @@ module TestPackage
 using HTTP,JSON
 using JSON3
 using LinearAlgebra
+using Catalyst
+using ModelingToolkit
 
 function extract_properties(data)
     # Extract the properties from the JSON data

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -1,0 +1,71 @@
+using HTTP, JSON ,Symbolics
+
+function get_json_from_url(url)
+    # Send HTTP GET request
+    resp = HTTP.get(url)
+
+    # Convert HTTP response to a string and parse it as JSON
+    return JSON.parse(String(resp.body))
+end
+
+function get_json_from_name(name)
+    return get_json_from_url("https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/$name/json")
+end
+
+function get_json_from_cid(cid)
+    return get_json_from_url("https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/$cid/json")
+end
+
+get_compound(x::Integer) = get_json_from_cid(x)
+get_compound(x::AbstractString) = get_json_from_name(x)
+
+function extract_properties(data)
+    # Extract the properties from the JSON data
+    properties = Dict(
+        "iupac_name_traditional" => data["PC_Compounds"][1]["props"][13]["value"]["sval"],
+        "iupac_name_preferred" => data["PC_Compounds"][1]["props"][12]["value"]["sval"],
+        "molecular_weight" => data["PC_Compounds"][1]["props"][18]["value"]["sval"],
+        "molecular_formula" => data["PC_Compounds"][1]["props"][17]["value"]["sval"],
+        "smiles" => data["PC_Compounds"][1]["props"][19]["value"]["sval"]
+    )
+
+    # Return the properties
+    return properties
+end
+
+function get_compound_properties(name)
+    # Fetch compound data
+    compound_data = get_compound(name)
+
+    # Extract and return properties
+    return extract_properties(compound_data)
+end
+
+struct Compound
+    var::Num
+    name ::String
+    metadata::Dict
+end
+
+function Compound(varname::String, compound_name::Union{String, Int})
+
+    @variables var = Symbol(varname)
+ 
+    # Store string representation 
+    name = varname
+ 
+    # Fetch compound data as metadata
+    metadata = get_compound_properties(compound_name)
+ 
+    # Create and return Compound
+    Compound(var, name, metadata)
+ end
+
+# Carbon = Compound("C","Carbon")
+# N = Compound("N", 947)
+# N.var    # gives you the variable
+# N.metadata  # gives you metadata dict
+# N.metadata["molecular_weight"]  # gives you the molecular weight directly
+
+# Carbon.metadata
+

--- a/src/testbalance.jl
+++ b/src/testbalance.jl
@@ -28,7 +28,7 @@ function parse_formula(formula)
 end
 
 function balance_reaction(reaction)
-    split_reaction = split(reaction, "→")
+    split_reaction = split(reaction, "-->")
     reactants = split(split_reaction[1], "+")
     products = split(split_reaction[2], "+")
 
@@ -73,9 +73,75 @@ function balance_reaction(reaction)
     balanced_reactants = [string(coeffs[j], reactants[j]) for j in 1:length(reactants)]
     balanced_products = [string(coeffs[j + length(reactants)], products[j]) for j in 1:length(products)]
     
-    balanced_reaction = join(balanced_reactants, " + ") * " → " * join(balanced_products, " + ")
+    balanced_reaction = join(balanced_reactants, "+") * "-->" * join(balanced_products, "+")
+    
+    # Remove all whitespaces
+    balanced_reaction = replace(balanced_reaction, " " => "")
     
     return balanced_reaction
 end
 
+
 export balance_reaction
+
+function extract_coefficients(reaction_str)
+    reactions = split(reaction_str, "-->") 
+
+    # get reactants and coefficients
+    reactants_info = split(reactions[1], "+")
+    reactant_coefficients = [parse(Int, r[1]) for r in reactants_info]
+
+    # get products and coefficients
+    products_info = split(reactions[2], "+")
+    product_coefficients = [parse(Int, p[1]) for p in products_info]
+
+    reactant_coefficients, product_coefficients
+end
+
+# reaction_str = "2H2+1O2-->2H2O" # your chemical equation here
+# reactant_coeff, product_coeff = extract_coefficients(reaction_str)
+# Gives 2 arrays with stoich values for reactants and products respectively
+# Assumes the coefficients to be always single digit for now
+
+function extract_species(reaction_str)
+    reactions = split(reaction_str, "-->") 
+
+    # get reactants and species
+    reactants_info = split(reactions[1], "+")
+    reactant_species = [String(r[2:end]) for r in reactants_info]
+
+    # get products and species
+    products_info = split(reactions[2], "+")
+    product_species = [String(p[2:end]) for p in products_info]
+
+    reactant_arr = vcat([eval(Meta.parse("@species $species(t)")) for species in reactant_species]...)
+    product_arr = vcat([eval(Meta.parse("@species $species(t)")) for species in product_species]...)
+
+    reactant_arr, product_arr
+end
+
+# reaction_str = "2H2+1O2-->2H2O" # your chemical equation here
+# reactant_coeff, product_coeff = extract_species(reaction_str)
+# Gives 2 arrays with species values for reactants and products respectively:(Num[H2(t), O2(t)], Num[H2O(t)]) 
+# Automatically creates the species required for the reaction 
+
+Reaction(k,reactant_arr  ,product_arr,reactant_coeff, product_coeff) #WORKS
+
+function create_balanced_reaction(reaction_str)
+    # Balance the reaction.
+    balanced_reaction_str = balance_reaction(reaction_str)
+
+    # Extract the coefficients and species from the balanced reaction.
+    reactant_coeff, product_coeff = extract_coefficients(balanced_reaction_str)
+    reactant_arr, product_arr = extract_species(balanced_reaction_str)
+
+    # Create and return the balanced reaction.
+    return Reaction(k, reactant_arr, product_arr, reactant_coeff, product_coeff)
+end
+
+# Example usage
+# reaction = create_balanced_reaction("CO2 + H2O --> C6H12O6 + O2") gives k, 6*CO2 + 6*H2O --> C6H12O6 + 6*O2
+# typeof(reaction) gives Reaction{Any, Int64}
+# println(reaction)
+# add this balanced reaction to a reaction network using Catalyst.!addreaction
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,17 +28,17 @@ end
 
 @show @testset "balance_reaction" begin
 # Test balance_reaction
-reaction1 = balance_reaction("H2 + O2 → H2O")
-@test reaction1 == "2H2 + 1O2 → 2H2O"
+reaction1 = balance_reaction("H2 + O2 --> H2O")
+@test reaction1 == "2H2+1O2-->2H2O"
 
-reaction2 = balance_reaction("C + O2 → CO2")
-@test reaction2 == "1C + 1O2 → 1CO2"
+reaction2 = balance_reaction("C + O2 --> CO2")
+@test reaction2 == "1C+1O2-->1CO2"
 
-reaction3 = balance_reaction("CO2 + H2O → C6H12O6 + O2")
-@test reaction3 == "6CO2 + 6H2O → 1C6H12O6 + 6O2"
+reaction3 = balance_reaction("CO2 + H2O --> C6H12O6 + O2")
+@test reaction3 == "6CO2+6H2O-->1C6H12O6+6O2"
 
-reaction4 = balance_reaction("H2 + Cl2 → HCl")
-@test reaction4 == "1H2 + 1Cl2 → 2HCl"
+reaction4 = balance_reaction("H2 + Cl2 --> HCl")
+@test reaction4 == "1H2+1Cl2-->2HCl"
 
 end
 


### PR DESCRIPTION
This adds the functionality of creating a balanced Catalyst reaction.
All we need to do is define the parameters and variables, no need to define the species using the @species macro as it is done automatically! :) 
We need to give the input of the reaction in a string format and the `create_balanced_reaction` function uses it to create a catalyst reaction and automatically balances it stoichiometrically. 

Example usage -
@parameters k
@variables t

julia> reaction = create_balanced_reaction("CO2 + H2O --> C6H12O6 + O2")
k, 6*CO2 + 6*H2O --> C6H12O6 + 6*O2

julia> typeof(reaction)
Reaction{Any, Int64}

julia> rn = Catalyst.make_empty_network()
Model ##ReactionSystem#295
States (0):
Parameters (0):

julia> addreaction!(rn,reaction)
1

julia> reactions(rn)
1-element Vector{Reaction}:
 k, 6*CO2 + 6*H2O --> C6H12O6 + 6*O2
 
 @anandijain






