### PR TITLE
Creating a balanced Catalyst reaction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestPackage"
 uuid = "1db272ca-bb6a-4d7c-9426-e93aef723262"
 authors = ["Lalit Chauhan"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
@@ -9,6 +9,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 
@@ -17,6 +18,7 @@ Catalyst = "13.3"
 HTTP = "1.9.6"
 JSON = "0.21.4"
 JSON3 = "1.13.1"
+ModelingToolkit = "8.62.0"
 Symbolics = "5.0"
 julia = "1.9"
 

--- a/src/TestPackage.jl
+++ b/src/TestPackage.jl
@@ -2,6 +2,8 @@ module TestPackage
 using HTTP,JSON
 using JSON3
 using LinearAlgebra
+using Catalyst
+using ModelingToolkit
 
 include("metadata.jl")
 include("testbalance.jl")

--- a/src/TestPackage.jl
+++ b/src/TestPackage.jl
@@ -16,5 +16,6 @@ export parse_formula
 export get_json_from_cid
 export get_json_from_name
 export get_json_from_url
+export create_balanced_reaction
 
 end

--- a/src/testbalance.jl
+++ b/src/testbalance.jl
@@ -125,7 +125,7 @@ end
 # Gives 2 arrays with species values for reactants and products respectively:(Num[H2(t), O2(t)], Num[H2O(t)]) 
 # Automatically creates the species required for the reaction 
 
-Reaction(k,reactant_arr  ,product_arr,reactant_coeff, product_coeff) #WORKS
+# Reaction(k,reactant_arr  ,product_arr,reactant_coeff, product_coeff) #WORKS
 
 function create_balanced_reaction(reaction_str)
     # Balance the reaction.

--- a/src/testbalance.jl
+++ b/src/testbalance.jl
@@ -28,7 +28,7 @@ function parse_formula(formula)
 end
 
 function balance_reaction(reaction)
-    split_reaction = split(reaction, "→")
+    split_reaction = split(reaction, "-->")
     reactants = split(split_reaction[1], "+")
     products = split(split_reaction[2], "+")
 
@@ -73,9 +73,74 @@ function balance_reaction(reaction)
     balanced_reactants = [string(coeffs[j], reactants[j]) for j in 1:length(reactants)]
     balanced_products = [string(coeffs[j + length(reactants)], products[j]) for j in 1:length(products)]
     
-    balanced_reaction = join(balanced_reactants, " + ") * " → " * join(balanced_products, " + ")
+    balanced_reaction = join(balanced_reactants, "+") * "-->" * join(balanced_products, "+")
+    
+    # Remove all whitespaces
+    balanced_reaction = replace(balanced_reaction, " " => "")
     
     return balanced_reaction
 end
 
+
 export balance_reaction
+
+function extract_coefficients(reaction_str)
+    reactions = split(reaction_str, "-->") 
+
+    # get reactants and coefficients
+    reactants_info = split(reactions[1], "+")
+    reactant_coefficients = [parse(Int, r[1]) for r in reactants_info]
+
+    # get products and coefficients
+    products_info = split(reactions[2], "+")
+    product_coefficients = [parse(Int, p[1]) for p in products_info]
+
+    reactant_coefficients, product_coefficients
+end
+
+# reaction_str = "2H2+1O2-->2H2O" # your chemical equation here
+# reactant_coeff, product_coeff = extract_coefficients(reaction_str)
+# Gives 2 arrays with stoich values for reactants and products respectively
+# Assumes the coefficients to be always single digit for now
+
+function extract_species(reaction_str)
+    reactions = split(reaction_str, "-->") 
+
+    # get reactants and species
+    reactants_info = split(reactions[1], "+")
+    reactant_species = [String(r[2:end]) for r in reactants_info]
+
+    # get products and species
+    products_info = split(reactions[2], "+")
+    product_species = [String(p[2:end]) for p in products_info]
+
+    reactant_arr = vcat([eval(Meta.parse("@species $species(t)")) for species in reactant_species]...)
+    product_arr = vcat([eval(Meta.parse("@species $species(t)")) for species in product_species]...)
+
+    reactant_arr, product_arr
+end
+
+# reaction_str = "2H2+1O2-->2H2O" # your chemical equation here
+# reactant_coeff, product_coeff = extract_species(reaction_str)
+# Gives 2 arrays with species values for reactants and products respectively:(Num[H2(t), O2(t)], Num[H2O(t)]) 
+# Automatically creates the species required for the reaction 
+
+Reaction(k,reactant_arr  ,product_arr,reactant_coeff, product_coeff) #WORKS
+
+function create_balanced_reaction(reaction_str)
+    # Balance the reaction.
+    balanced_reaction_str = balance_reaction(reaction_str)
+
+    # Extract the coefficients and species from the balanced reaction.
+    reactant_coeff, product_coeff = extract_coefficients(balanced_reaction_str)
+    reactant_arr, product_arr = extract_species(balanced_reaction_str)
+
+    # Create and return the balanced reaction.
+    return Reaction(k, reactant_arr, product_arr, reactant_coeff, product_coeff)
+end
+
+# Example usage
+# reaction = create_balanced_reaction("CO2 + H2O --> C6H12O6 + O2") gives k, 6*CO2 + 6*H2O --> C6H12O6 + 6*O2
+# typeof(reaction) gives Reaction{Any, Int64}
+# println(reaction)
+# add this balanced reaction to a reaction network using Catalyst.!addreaction

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,17 +26,17 @@ end
 
 @testset "balance_reaction" begin
 # Test balance_reaction
-reaction1 = balance_reaction("H2 + O2 → H2O")
-@test reaction1 == "2H2 + 1O2 → 2H2O"
+reaction1 = balance_reaction("H2 + O2 --> H2O")
+@test reaction1 == "2H2+1O2-->2H2O"
 
-reaction2 = balance_reaction("C + O2 → CO2")
-@test reaction2 == "1C + 1O2 → 1CO2"
+reaction2 = balance_reaction("C + O2 --> CO2")
+@test reaction2 == "1C+1O2-->1CO2"
 
-reaction3 = balance_reaction("CO2 + H2O → C6H12O6 + O2")
-@test reaction3 == "6CO2 + 6H2O → 1C6H12O6 + 6O2"
+reaction3 = balance_reaction("CO2 + H2O --> C6H12O6 + O2")
+@test reaction3 == "6CO2+6H2O-->1C6H12O6+6O2"
 
-reaction4 = balance_reaction("H2 + Cl2 → HCl")
-@test reaction4 == "1H2 + 1Cl2 → 2HCl"
+reaction4 = balance_reaction("H2 + Cl2 --> HCl")
+@test reaction4 == "1H2+1Cl2-->2HCl"
 
 end
 


### PR DESCRIPTION
This adds the functionality of creating a balanced Catalyst reaction.
All we need to do is define the parameters and variables, no need to define the species using the @species macro as they are created automatically! :)
We need to give the input of the reaction in a string format and the create_balanced_reaction function uses it to create a catalyst reaction and automatically balances it stoichiometrically.

Example usage -
```
@parameters k
@variables t

julia> reaction = create_balanced_reaction("CO2 + H2O --> C6H12O6 + O2")
k, 6CO2 + 6H2O --> C6H12O6 + 6*O2

julia> typeof(reaction)
Reaction{Any, Int64}

julia> rn = Catalyst.make_empty_network()
Model ##ReactionSystem#295
States (0):
Parameters (0):

julia> addreaction!(rn,reaction)
1

julia> reactions(rn)
1-element Vector{Reaction}:
k, 6CO2 + 6H2O --> C6H12O6 + 6*O2
```

@anandijain